### PR TITLE
Adds Prime 192 curve

### DIFF
--- a/Sources/CryptorECC/ECPrivateKey.swift
+++ b/Sources/CryptorECC/ECPrivateKey.swift
@@ -214,7 +214,6 @@ public class ECPrivateKey {
                               0x30, 0x13,
                               0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
                               0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x01, 0x03, 0x32])
-            
         } else if self.curve == .prime256v1 {
             keyHeader = Data([0x30, 0x59,
                               0x30, 0x13,
@@ -287,7 +286,9 @@ public class ECPrivateKey {
         #else
         let kAsymmetricCryptoManagerKeyType = kSecAttrKeyTypeECSECPrimeRandom
         let kAsymmetricCryptoManagerKeySize: Int
-        if curve == .prime256v1 {
+        if curve == .prime192v1 {
+            kAsymmetricCryptoManagerKeySize = 192
+        } else if curve == .prime256v1 {
             kAsymmetricCryptoManagerKeySize = 256
         } else if curve == .secp384r1 {
             kAsymmetricCryptoManagerKeySize = 384

--- a/Sources/CryptorECC/ECPrivateKey.swift
+++ b/Sources/CryptorECC/ECPrivateKey.swift
@@ -209,7 +209,13 @@ public class ECPrivateKey {
         //         OBJECT IDENTIFIER
         //         OBJECT IDENTIFIER
         //     BIT STRING (This is the `pubKeyBytes` added afterwards)
-        if self.curve == .prime256v1 {
+        if self.curve == .prime192v1 {
+            keyHeader = Data([0x30, 0x49,
+                              0x30, 0x13,
+                              0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
+                              0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x01, 0x03, 0x32])
+            
+        } else if self.curve == .prime256v1 {
             keyHeader = Data([0x30, 0x59,
                               0x30, 0x13,
                               0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,

--- a/Sources/CryptorECC/EllipticCurve.swift
+++ b/Sources/CryptorECC/EllipticCurve.swift
@@ -29,8 +29,11 @@ public struct EllipticCurve: Equatable, CustomStringConvertible {
     
     // enum for faster comparisons
     private enum InternalRepresentation: String {
-        case prime256v1, secp384r1, secp521r1
+        case prime256v1, secp384r1, secp521r1, prime192v1
     }
+    
+    /// A prime 192 curve
+    public static let prime192v1 = EllipticCurve.p192
     
     /// A prime256v1 curve.
     public static let prime256v1 = EllipticCurve.p256
@@ -84,6 +87,12 @@ public struct EllipticCurve: Equatable, CustomStringConvertible {
                                     nativeCurve: NID_secp521r1,
                                     keySize: 133)
     #else
+    /// Secure Hash Algorithm 2 192-bit
+    static let p192 = EllipticCurve(internalRepresentation: .prime192v1,
+                                    signingAlgorithm: .ecdsaSignatureDigestX962SHA256,
+                                    hashEngine: CC_SHA256,
+                                    hashLength: CC_LONG(CC_SHA256_DIGEST_LENGTH),
+                                    keySize: 49)
     /// Secure Hash Algorithm 2 256-bit
     static let p256 = EllipticCurve(internalRepresentation: .prime256v1,
                                     signingAlgorithm: .ecdsaSignatureDigestX962SHA256,
@@ -108,8 +117,10 @@ public struct EllipticCurve: Equatable, CustomStringConvertible {
     
     // Select the ECAlgorithm based on the object identifier (OID) extracted from the EC key.
     static func objectToCurve(ObjectIdentifier: Data) throws -> EllipticCurve {
-        
-        if [UInt8](ObjectIdentifier) == [0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07] {
+
+        if [UInt8](ObjectIdentifier) == [0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x01] { // 1.2.840.10045.3.1.1
+            return .prime192v1
+        } else if [UInt8](ObjectIdentifier) == [0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07] { //1.2.840.10045.3.1.7
             // p-256 (e.g: prime256v1, secp256r1) private key
             return .prime256v1
         } else if [UInt8](ObjectIdentifier) == [0x2B, 0x81, 0x04, 0x00, 0x22] {

--- a/Tests/CryptorECCTests/CryptorECCTests.swift
+++ b/Tests/CryptorECCTests/CryptorECCTests.swift
@@ -460,6 +460,12 @@ Mw==
     
     func test_newPrivatekey() {
         do {
+            let p192PrivateKey = try ECPrivateKey.make(for: .prime192v1)
+            let p192PubKey = try p192PrivateKey.extractPublicKey()
+            let p192signature = try "Hello world".sign(with: p192PrivateKey)
+            let p192verified = p192signature.verify(plaintext: "Hello world", using: p192PubKey)
+            XCTAssertTrue(p192verified)
+            
             let p256PrivateKey = try ECPrivateKey.make(for: .prime256v1)
             let p256PubKey = try p256PrivateKey.extractPublicKey()
             let signature = try "Hello world".sign(with: p256PrivateKey)


### PR DESCRIPTION
- Support a specific implementation where prime 192 curve is required
- Private key generation test added
- My attempts to add a `test_newKeyToPEM` for p192 keys failed may need some guidance